### PR TITLE
feat: display projects from Contentful

### DIFF
--- a/src/components/ProjectGrid.tsx
+++ b/src/components/ProjectGrid.tsx
@@ -1,0 +1,30 @@
+import { Project } from "@/lib/contentful";
+
+interface Props {
+  projects: Project[];
+}
+
+export default function ProjectGrid({ projects }: Props) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+        gap: "1.5rem",
+      }}
+    >
+      {projects.map((p) => (
+        <div key={p.sys.id}>
+          {p.fields.thumbnail && (
+            <img
+              src={`https:${p.fields.thumbnail.fields.file.url}`}
+              alt={p.fields.title}
+              style={{ width: "100%", height: "auto", display: "block" }}
+            />
+          )}
+          <h3>{p.fields.title}</h3>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/contentful.ts
+++ b/src/lib/contentful.ts
@@ -13,3 +13,18 @@ export async function cfFetch<T>(path: string) {
   if (!res.ok) throw new Error(`Contentful ${res.status}`);
   return (await res.json()) as T;
 }
+
+export type Project = {
+  sys: { id: string };
+  fields: {
+    title: string;
+    thumbnail?: { fields: { file: { url: string } } };
+  };
+};
+
+export async function getProjects() {
+  const { items } = await cfFetch<{ items: Project[] }>(
+    "entries?content_type=project&include=1"
+  );
+  return items;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,26 @@
 import Head from "next/head";
+import ProjectGrid from "@/components/ProjectGrid";
+import { getProjects, type Project } from "@/lib/contentful";
 
-export default function Home() {
+interface HomeProps {
+  projects: Project[];
+}
+
+export default function Home({ projects }: HomeProps) {
   return (
     <>
       <Head>
         <title>Studio vidéo — Démo</title>
         <meta name="description" content="Plateforme vidéo & pub" />
       </Head>
-      <main style={{minHeight:"60vh", display:"grid", placeItems:"center"}}>
-        <h1 style={{fontFamily:"system-ui, sans-serif"}}>Hello, ça build 🔧</h1>
+      <main style={{ padding: "2rem" }}>
+        <ProjectGrid projects={projects} />
       </main>
     </>
   );
+}
+
+export async function getStaticProps() {
+  const projects = await getProjects();
+  return { props: { projects } };
 }


### PR DESCRIPTION
## Summary
- fetch projects from Contentful API
- show project titles and thumbnails in a responsive grid
- render projects on the home page at build time

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c782eda0832484c0fb423e0097e8