### PR TITLE
Add contact page with layout navigation and form styles

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function Layout({ children }: Props) {
+  return (
+    <>
+      <header>
+        <nav>
+          <ul style={{display:"flex", gap:"1rem", listStyle:"none", padding:0, margin:0}}>
+            <li>
+              <Link href="/">Accueil</Link>
+            </li>
+            <li>
+              <Link href="/contact">Contact</Link>
+            </li>
+          </ul>
+        </nav>
+      </header>
+      <main>{children}</main>
+    </>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,11 @@
 import type { AppProps } from "next/app";
+import Layout from "@/components/Layout";
 import "@/styles/globals.css";
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
 }

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,34 @@
+import Head from "next/head";
+import { FormEvent } from "react";
+
+export default function Contact() {
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    // Future implementation: send form data
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Contact</title>
+      </Head>
+      <section style={{minHeight:"60vh", display:"grid", placeItems:"center"}}>
+        <form className="contact-form" onSubmit={handleSubmit}>
+          <label htmlFor="name">
+            Nom
+            <input id="name" name="name" type="text" required />
+          </label>
+          <label htmlFor="email">
+            Email
+            <input id="email" name="email" type="email" required />
+          </label>
+          <label htmlFor="message">
+            Message
+            <textarea id="message" name="message" rows={5} required />
+          </label>
+          <button type="submit">Envoyer</button>
+        </form>
+      </section>
+    </>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,3 +8,48 @@ body {
   font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
 }
 a { color: inherit; text-decoration: none; }
+
+form.contact-form {
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+form.contact-form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+}
+
+form.contact-form input,
+form.contact-form textarea {
+  padding: 0.5rem;
+  border: 1px solid #666;
+  border-radius: 4px;
+  background: #fff;
+  color: #000;
+}
+
+form.contact-form button {
+  align-self: flex-start;
+  padding: 0.6rem 1.2rem;
+  border: none;
+  border-radius: 4px;
+  background: #0070f3;
+  color: #fff;
+  cursor: pointer;
+}
+
+form.contact-form button:hover {
+  background: #0059c1;
+}
+
+@media (min-width: 640px) {
+  form.contact-form {
+    padding: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add basic Layout with navigation and Contact link
- implement Contact page with simple form
- provide responsive form styles

## Testing
- `npm test`
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c95b17ac832481764111de495369